### PR TITLE
Fix boot crash: guard ESP_LOG during static initialization

### DIFF
--- a/components/ups_hid/protocol_factory.cpp
+++ b/components/ups_hid/protocol_factory.cpp
@@ -1,6 +1,7 @@
 #include "protocol_factory.h"
 #include "ups_hid.h"
 #include "esphome/core/log.h"
+#include "esphome/components/logger/logger.h"
 #include <algorithm>
 
 namespace esphome {
@@ -26,7 +27,8 @@ void ProtocolFactory::ensure_initialized() {
     // This function exists for explicit initialization if needed
     static bool initialized = false;
     if (!initialized) {
-        ESP_LOGD(FACTORY_TAG, "Protocol factory registries initialized");
+        if (esphome::logger::global_logger != nullptr)
+            ESP_LOGD(FACTORY_TAG, "Protocol factory registries initialized");
         initialized = true;
     }
 }
@@ -44,8 +46,9 @@ void ProtocolFactory::register_protocol_for_vendor(uint16_t vendor_id,
                   return a.priority > b.priority;
               });
     
-    ESP_LOGI(FACTORY_TAG, "Registered protocol '%s' for vendor 0x%04X (priority %d)", 
-             info.name.c_str(), vendor_id, info.priority);
+    if (esphome::logger::global_logger != nullptr)
+        ESP_LOGI(FACTORY_TAG, "Registered protocol '%s' for vendor 0x%04X (priority %d)",
+                 info.name.c_str(), vendor_id, info.priority);
 }
 
 void ProtocolFactory::register_fallback_protocol(const ProtocolInfo& info) {
@@ -60,8 +63,9 @@ void ProtocolFactory::register_fallback_protocol(const ProtocolInfo& info) {
                   return a.priority > b.priority;
               });
     
-    ESP_LOGI(FACTORY_TAG, "Registered fallback protocol '%s' (priority %d)", 
-             info.name.c_str(), info.priority);
+    if (esphome::logger::global_logger != nullptr)
+        ESP_LOGI(FACTORY_TAG, "Registered fallback protocol '%s' (priority %d)",
+                 info.name.c_str(), info.priority);
 }
 
 std::unique_ptr<UpsProtocolBase> 


### PR DESCRIPTION
## Summary
- Guard 3 `ESP_LOG*` calls in `protocol_factory.cpp` with `global_logger != nullptr` checks
- These calls run during C++ static initialization (via `REGISTER_UPS_*` macros) before the ESPHome Logger is constructed
- Without the guard, dereferencing the null logger pointer causes `Guru Meditation Error: Core 0 panic'ed (LoadProhibited)` at `EXCVADDR: 0x0000002c` on every boot

## Root Cause
`REGISTER_UPS_PROTOCOL_FOR_VENDOR` / `REGISTER_UPS_FALLBACK_PROTOCOL` macros create file-scope static variables whose constructors call `register_protocol_for_vendor()` → `ensure_initialized()` → `ESP_LOGD()` during `do_global_ctors`, before `main()` runs.

## Test plan
- [x] Tested on ESP32-S3-DevKitC-1 with ESPHome 2026.3.0 / ESP-IDF 5.5.3
- [x] Confirmed crash without fix, clean boot with fix
- [x] Logs still appear at runtime when called after Logger construction

Fixes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)