### PR TITLE
fix: auto-load button and number components to resolve missing headers

### DIFF
--- a/components/ups_hid/__init__.py
+++ b/components/ups_hid/__init__.py
@@ -8,6 +8,7 @@ from esphome.const import (
 )
 
 DEPENDENCIES = ["esp32"]
+AUTO_LOAD = ["button", "number"]
 MULTI_CONF = True
 
 CONF_SIMULATION_MODE = "simulation_mode"


### PR DESCRIPTION
control_button.h and control_number.h include esphome/components/button/button.h and esphome/components/number/number.h respectively. Since these .cpp files are always compiled as part of ups_hid, the button and number ESPHome components must always be available via AUTO_LOAD.

https://claude.ai/code/session_01QExLNFd9S4WLfrEaQ2k5HY